### PR TITLE
Fix/add tests: Added more unittests

### DIFF
--- a/paystackpay/base.py
+++ b/paystackpay/base.py
@@ -43,5 +43,3 @@ class Base(object):
             return response_json
         except requests.exceptions.RequestException as e:
             raise Exception(f"error: {str(e)}")
-        
-        

--- a/paystackpay/customer.py
+++ b/paystackpay/customer.py
@@ -11,16 +11,11 @@ class Customer(Base):
             "last_name":last_name,
             "phone": phone
         }
-
-
         return self.make_request("POST",endpoint=endpoint,data=data)
-    
-    
 
     def list_costumers(self):
         endpoint = 'customer'
-        return self.make_request("GET",endpoint=endpoint)
-    
+        return self.make_request("GET",endpoint=endpoint)    
 
     def fetch_customer(self,email_or_customer_code:str):
         endpoint = f"customer/{email_or_customer_code}"

--- a/paystackpay/pay_requests.py
+++ b/paystackpay/pay_requests.py
@@ -35,7 +35,7 @@ class PaymentRequest(Base):
     
     def send_notification(self,request_code:str):
         endpoint = f"paymentrequest/notify/{request_code}"
-        return self.make_request("GET",endpoint=endpoint)
+        return self.make_request("POST",endpoint=endpoint)
     
 
 

--- a/paystackpay/transaction.py
+++ b/paystackpay/transaction.py
@@ -78,14 +78,3 @@ class Transaction(Base):
         }
 
         return self.make_request("POST",endpoint=endpoint,data=data)
-    
-
-
-
-
-    
-
-
-
-
-

--- a/tests/mock_responses/mock_customer.py
+++ b/tests/mock_responses/mock_customer.py
@@ -1,0 +1,147 @@
+mock_create_customer_response = {
+  "status": True,
+  "message": "Customer created",
+  "data": {
+    "email": "test@example.com",
+    "integration": 100032,
+    "domain": "test",
+    "customer_code": "CUS_ng9mw56ma4cx6x9",
+    "id": 1173,
+    "identified": False,
+    "identifications": None,
+    "createdAt": "2016-03-29T20:03:09.584Z",
+    "updatedAt": "2016-03-29T20:03:09.584Z"
+  }    
+}
+
+mock_update_customer_response = {
+  "status": True,
+  "message": "Customer updated",
+  "data": {
+    "integration": 100032,
+    "first_name": "UpdatedFirstName",
+    "last_name": "UpdatedLastName",
+    "email": "bojack@horsinaround.com",
+    "phone": None,
+    "metadata": {
+      "photos": [
+        {
+          "type": "twitter",
+          "typeId": "twitter",
+          "typeName": "Twitter",
+          "url": "https://d2ojpxxtu63wzl.cloudfront.net/static/61b1a0a1d4dda2c9fe9e165fed07f812_a722ae7148870cc2e33465d1807dfdc6efca33ad2c4e1f8943a79eead3c21311",
+          "isPrimary": True
+        }
+      ]
+    },
+    "identified": False,
+    "identifications": None,
+    "domain": "test",
+    "customer_code": "CUS_ng9mw56ma4cx6x9",
+    "id": 1173,
+    "transactions": [],
+    "subscriptions": [],
+    "authorizations": [],
+    "createdAt": "2016-03-29T20:03:09.000Z",
+    "updatedAt": "2016-03-29T20:03:10.000Z"
+  }
+}
+
+mock_list_customer_response = {
+  "status": True,
+  "message": "Customers retrieved",
+  "data": [
+    {
+      "integration": 463433,
+      "first_name": None,
+      "last_name": None,
+      "email": "dom@gmail.com",
+      "phone": None,
+      "metadata": None,
+      "domain": "test",
+      "customer_code": "CUS_c6wqvwmvwopw4ms",
+      "risk_action": "default",
+      "id": 90758908,
+      "createdAt": "2022-08-15T13:46:39.000Z",
+      "updatedAt": "2022-08-15T13:46:39.000Z"
+    },
+    {
+      "integration": 463433,
+      "first_name": "Okiki",
+      "last_name": "Sample",
+      "email": "okiki@sample.com",
+      "phone": "09048829123",
+      "metadata": {},
+      "domain": "test",
+      "customer_code": "CUS_rki2ccocw7g8lsj",
+      "risk_action": "default",
+      "id": 90758301,
+      "createdAt": "2022-08-15T13:42:52.000Z",
+      "updatedAt": "2022-08-15T13:42:52.000Z"
+    },
+    {
+      "integration": 463433,
+      "first_name": "lukman",
+      "last_name": "calle",
+      "email": "lukman@calle.co",
+      "phone": "08922383034",
+      "metadata": {},
+      "domain": "test",
+      "customer_code": "CUS_hpxsz8c1if90quo",
+      "risk_action": "default",
+      "id": 90747194,
+      "createdAt": "2022-08-15T12:31:13.000Z",
+      "updatedAt": "2022-08-15T12:31:13.000Z"
+    }
+  ],
+  "meta": {
+    "next": "Y3VzdG9tZXI6OTAyMjU4MDk=",
+    "previous": None,
+    "perPage": 3
+  }    
+}
+
+mock_fetch_customer_response = {
+  "status": True,
+  "message": "Customer retrieved",
+  "data": {
+    "transactions": [],
+    "subscriptions": [],
+    "authorizations": [
+      {
+        "authorization_code": "AUTH_ekk8t49ogj",
+        "bin": "408408",
+        "last4": "4081",
+        "exp_month": "12",
+        "exp_year": "2030",
+        "channel": "card",
+        "card_type": "visa ",
+        "bank": "TEST BANK",
+        "country_code": "NG",
+        "brand": "visa",
+        "reusable": True,
+        "signature": "SIG_yEXu7dLBeqG0kU7g95Ke",
+        "account_name": None
+      }
+    ],
+    "first_name": None,
+    "last_name": None,
+    "email": "test@example.com",
+    "phone": None,
+    "metadata": None,
+    "domain": "test",
+    "customer_code": "CUS_c6wqvwmvwopw4ms",
+    "risk_action": "default",
+    "id": 90758908,
+    "integration": 463433,
+    "createdAt": "2022-08-15T13:46:39.000Z",
+    "updatedAt": "2022-08-15T13:46:39.000Z",
+    "created_at": "2022-08-15T13:46:39.000Z",
+    "updated_at": "2022-08-15T13:46:39.000Z",
+    "total_transactions": 0,
+    "total_transaction_value": [],
+    "dedicated_account": None,
+    "identified": False,
+    "identifications": None
+  }    
+}

--- a/tests/mock_responses/mock_pay_request.py
+++ b/tests/mock_responses/mock_pay_request.py
@@ -1,0 +1,237 @@
+mock_create_pay_request = {
+  "status": True,
+  "message": "Payment request created",
+  "data": {
+    "id": 3136406,
+    "domain": "test",
+    "amount": 42000,
+    "currency": "NGN",
+    "due_date": "2020-07-08T00:00:00.000Z",
+    "has_invoice": True,
+    "invoice_number": 1,
+    "description": "a test invoice",
+    "line_items": [
+      {
+        "name": "item 1",
+        "amount": 20000
+      },
+      {
+        "name": "item 2",
+        "amount": 20000
+      }
+    ],
+    "tax": [
+      {
+        "name": "VAT",
+        "amount": 2000
+      }
+    ],
+    "request_code": "PRQ_1weqqsn2wwzgft8",
+    "status": "pending",
+    "paid": False,
+    "metadata": None,
+    "notifications": [],
+    "offline_reference": "4286263136406",
+    "customer": 25833615,
+    "created_at": "2020-06-29T16:07:33.073Z"
+  }    
+}
+
+mock_fetch_pay_request = {
+  "status": True,
+  "message": "Payment request retrieved",
+  "data": {
+    "transactions": [],
+    "domain": "test",
+    "request_code": "PRQ_53s49t73kq6qmsq",
+    "description": "a test invoice",
+    "line_items": [
+      {
+        "name": "item 1",
+        "amount": 20000
+      },
+      {
+        "name": "item 2",
+        "amount": 20000
+      }
+    ],
+    "tax": [
+      {
+        "name": "VAT",
+        "amount": 2000
+      }
+    ],
+    "amount": 42000,
+    "discount": None,
+    "currency": "NGN",
+    "due_date": "2020-07-08T00:00:00.000Z",
+    "status": "pending",
+    "paid": False,
+    "paid_at": None,
+    "metadata": None,
+    "has_invoice": True,
+    "invoice_number": 1,
+    "offline_reference": "4286263136406",
+    "pdf_url": None,
+    "notifications": [],
+    "archived": False,
+    "source": "user",
+    "payment_method": None,
+    "note": None,
+    "amount_paid": None,
+    "id": 3136406,
+    "integration": 428626,
+    "customer": {
+      "transactions": [],
+      "subscriptions": [],
+      "authorizations": [],
+      "first_name": "Damilola",
+      "last_name": "Odujoko",
+      "email": "damilola@example.com",
+      "phone": None,
+      "metadata": {
+        "calling_code": "+234"
+      },
+      "domain": "test",
+      "customer_code": "CUS_xwaj0txjryg393b",
+      "risk_action": "default",
+      "id": 25833615,
+      "integration": 428626,
+      "createdAt": "2020-06-29T16:06:53.000Z",
+      "updatedAt": "2020-06-29T16:06:53.000Z"
+    },
+    "createdAt": "2020-06-29T16:07:33.000Z",
+    "updatedAt": "2020-06-29T16:07:33.000Z",
+    "pending_amount": 42000
+  }    
+}
+
+mock_list_pay_request = {
+  "status": True,
+  "message": "Payment requests retrieved",
+  "data": [
+    {
+      "id": 3136406,
+      "domain": "test",
+      "amount": 42000,
+      "currency": "NGN",
+      "due_date": "2020-07-08T00:00:00.000Z",
+      "has_invoice": True,
+      "invoice_number": 1,
+      "description": "a test invoice",
+      "pdf_url": None,
+      "line_items": [
+        {
+          "name": "item 1",
+          "amount": 20000
+        },
+        {
+          "name": "item 2",
+          "amount": 20000
+        }
+      ],
+      "tax": [
+        {
+          "name": "VAT",
+          "amount": 2000
+        }
+      ],
+      "request_code": "PRQ_1weqqsn2wwzgft8",
+      "status": "pending",
+      "paid": False,
+      "paid_at": None,
+      "metadata": None,
+      "notifications": [],
+      "offline_reference": "4286263136406",
+      "customer": {
+        "id": 25833615,
+        "first_name": "Damilola",
+        "last_name": "Odujoko",
+        "email": "damilola@example.com",
+        "customer_code": "CUS_xwaj0txjryg393b",
+        "phone": None,
+        "metadata": {
+          "calling_code": "+234"
+        },
+        "risk_action": "default",
+        "international_format_phone": None
+      },
+      "created_at": "2020-06-29T16:07:33.000Z"
+    }
+  ],
+  "meta": {
+    "total": 1,
+    "skipped": 0,
+    "perPage": 50,
+    "page": 1,
+    "pageCount": 1
+  }    
+}
+
+mock_verify_pay_request = {
+  "status": True,
+  "message": "Payment request retrieved",
+  "data": {
+    "id": 3136406,
+    "domain": "test",
+    "amount": 42000,
+    "currency": "NGN",
+    "due_date": "2020-07-08T00:00:00.000Z",
+    "has_invoice": True,
+    "invoice_number": 1,
+    "description": "a test invoice",
+    "pdf_url": None,
+    "line_items": [
+      {
+        "name": "item 1",
+        "amount": 20000
+      },
+      {
+        "name": "item 2",
+        "amount": 20000
+      }
+    ],
+    "tax": [
+      {
+        "name": "VAT",
+        "amount": 2000
+      }
+    ],
+    "request_code": "PRQ_53s49t73kq6qmsq",
+    "status": "pending",
+    "paid": False,
+    "paid_at": None,
+    "metadata": None,
+    "notifications": [],
+    "offline_reference": "4286263136406",
+    "customer": {
+      "id": 25833615,
+      "first_name": "Damilola",
+      "last_name": "Odujoko",
+      "email": "damilola@example.com",
+      "customer_code": "CUS_xwaj0txjryg393b",
+      "phone": None,
+      "metadata": {
+        "calling_code": "+234"
+      },
+      "risk_action": "default",
+      "international_format_phone": None
+    },
+    "created_at": "2020-06-29T16:07:33.000Z",
+    "integration": {
+      "key": "pk_test_xxxxxxxx",
+      "name": "Paystack Documentation",
+      "logo": "https://s3-eu-west-1.amazonaws.com/pstk-integration-logos/paystack.jpg",
+      "allowed_currencies": [
+        "NGN",
+        "USD"
+      ]
+    },
+    "pending_amount": 42000
+  }    
+}
+
+mock_send_notification = {
+  "status": True,
+  "message": "Notification sent"    
+}

--- a/tests/mock_responses/mock_plans.py
+++ b/tests/mock_responses/mock_plans.py
@@ -1,0 +1,134 @@
+mock_create_plans = {
+  "status": True,
+  "message": "Plan created",
+  "data": {
+    "name": "Monthly Platinum Session",
+    "amount": 10000,
+    "interval": "monthly",
+    "integration": 100032,
+    "domain": "test",
+    "plan_code": "PLN_gx2wn530m0i3w3m",
+    "send_invoices": True,
+    "send_sms": True,
+    "hosted_page": False,
+    "currency": "NGN",
+    "id": 28,
+    "createdAt": "2016-03-29T22:42:50.811Z",
+    "updatedAt": "2016-03-29T22:42:50.811Z"
+  }    
+}
+mock_list_plans = {
+  "status": True,
+  "message": "Plans retrieved",
+  "data": [
+    {
+      "subscriptions": [
+        {
+          "customer": 63,
+          "plan": 27,
+          "integration": 100032,
+          "domain": "test",
+          "start": 1458505748,
+          "status": "complete",
+          "quantity": 1,
+          "amount": 100000,
+          "subscription_code": "SUB_birvokwpp0sftun",
+          "email_token": "9y62mxp4uh25das",
+          "authorization": {
+            "authorization_code": "AUTH_6tmt288t0o",
+            "bin": "408408",
+            "last4": "4081",
+            "exp_month": "12",
+            "exp_year": "2020",
+            "channel": "card",
+            "card_type": "visa visa",
+            "bank": "TEST BANK",
+            "country_code": "NG",
+            "brand": "visa",
+            "reusable": True,
+            "signature": "SIG_uSYN4fv1adlAuoij8QXh",
+            "account_name": "BoJack Horseman"
+          },
+          "easy_cron_id": None,
+          "cron_expression": "0 0 * * 0",
+          "next_payment_date": "2016-03-27T07:00:00.000Z",
+          "open_invoice": None,
+          "id": 8,
+          "createdAt": "2016-03-20T20:29:08.000Z",
+          "updatedAt": "2016-03-22T16:23:52.000Z"
+        }
+      ],
+      "integration": 100032,
+      "domain": "test",
+      "name": "Satin Flower",
+      "plan_code": "PLN_lkozbpsoyd4je9t",
+      "description": None,
+      "amount": 100000,
+      "interval": "weekly",
+      "send_invoices": True,
+      "send_sms": True,
+      "hosted_page": False,
+      "hosted_page_url": None,
+      "hosted_page_summary": None,
+      "currency": "NGN",
+      "id": 27,
+      "createdAt": "2016-03-21T02:44:14.000Z",
+      "updatedAt": "2016-03-21T02:44:14.000Z"
+    },
+    {
+      "subscriptions": [],
+      "integration": 100032,
+      "domain": "test",
+      "name": "Monthly retainer",
+      "plan_code": "PLN_gx2wn530m0i3w3m",
+      "description": None,
+      "amount": 50000,
+      "interval": "monthly",
+      "send_invoices": True,
+      "send_sms": True,
+      "hosted_page": False,
+      "hosted_page_url": None,
+      "hosted_page_summary": None,
+      "currency": "NGN",
+      "id": 28,
+      "createdAt": "2016-03-29T22:42:50.000Z",
+      "updatedAt": "2016-03-29T22:42:50.000Z"
+    }
+  ],
+  "meta": {
+    "total": 2,
+    "skipped": 0,
+    "perPage": 50,
+    "page": 1,
+    "pageCount": 1
+  }
+}
+
+mock_fetch_plan = {
+  "status": True,
+  "message": "Plan retrieved",
+  "data": {
+    "subscriptions": [],
+    "integration": 100032,
+    "domain": "test",
+    "name": "Monthly retainer",
+    "plan_code": "PLN_cfd3s2sdmqxravk",
+    "description": None,
+    "amount": 50000,
+    "interval": "monthly",
+    "send_invoices": True,
+    "send_sms": True,
+    "hosted_page": False,
+    "hosted_page_url": None,
+    "hosted_page_summary": None,
+    "currency": "NGN",
+    "id": 28,
+    "createdAt": "2016-03-29T22:42:50.000Z",
+    "updatedAt": "2016-03-29T22:42:50.000Z"
+  }
+}
+
+mock_update_plan = {
+  "status": True,
+  "message": "Plan updated. 1 subscription(s) affected"    
+}

--- a/tests/mock_responses/mock_transactions.py
+++ b/tests/mock_responses/mock_transactions.py
@@ -1,0 +1,462 @@
+mock_initialize_transactions = {
+  "status": True,
+  "message": "Authorization URL created",
+  "data": {
+    "authorization_url": "https://checkout.paystack.com/3ni8kdavz62431k",
+    "access_code": "3ni8kdavz62431k",
+    "reference": "re4lyvq3s3"
+  }
+}
+
+mock_verify_transaction = {
+  "status": True,
+  "message": "Verification successful",
+  "data": {
+    "id": 4099260516,
+    "domain": "test",
+    "status": "success",
+    "reference": "mko157u44s",
+    "receipt_number": None,
+    "amount": 40333,
+    "message": None,
+    "gateway_response": "Successful",
+    "paid_at": "2024-08-22T09:15:02.000Z",
+    "created_at": "2024-08-22T09:14:24.000Z",
+    "channel": "card",
+    "currency": "NGN",
+    "ip_address": "197.210.54.33",
+    "metadata": "",
+    "log": {
+      "start_time": 1724318098,
+      "time_spent": 4,
+      "attempts": 1,
+      "errors": 0,
+      "success": True,
+      "mobile": False,
+      "input": [],
+      "history": [
+        {
+          "type": "action",
+          "message": "Attempted to pay with card",
+          "time": 3
+        },
+        {
+          "type": "success",
+          "message": "Successfully paid with card",
+          "time": 4
+        }
+      ]
+    },
+    "fees": 10283,
+    "fees_split": None,
+    "authorization": {
+      "authorization_code": "AUTH_uh8bcl3zbn",
+      "bin": "408408",
+      "last4": "4081",
+      "exp_month": "12",
+      "exp_year": "2030",
+      "channel": "card",
+      "card_type": "visa ",
+      "bank": "TEST BANK",
+      "country_code": "NG",
+      "brand": "visa",
+      "reusable": None,
+      "signature": "SIG_yEXu7dLBeqG0kU7g95Ke",
+      "account_name": None
+    },
+    "customer": {
+      "id": 181873746,
+      "first_name": None,
+      "last_name": None,
+      "email": "demo@test.com",
+      "customer_code": "CUS_1rkzaqsv4rrhqo6",
+      "phone": None,
+      "metadata": None,
+      "risk_action": "default",
+      "international_format_phone": None
+    },
+    "plan": None,
+    "split": {},
+    "order_id": None,
+    "paidAt": "2024-08-22T09:15:02.000Z",
+    "createdAt": "2024-08-22T09:14:24.000Z",
+    "requested_amount": 30050,
+    "pos_transaction_data": None,
+    "source": None,
+    "fees_breakdown": None,
+    "connect": None,
+    "transaction_date": "2024-08-22T09:14:24.000Z",
+    "plan_object": {},
+    "subaccount": {}
+  }    
+}
+
+mock_list_transactions = {
+  "status": True,
+  "message": "Transactions retrieved",
+  "data": [
+    {
+      "id": 4099260516,
+      "domain": "test",
+      "status": "success",
+      "reference": "re4lyvq3s3",
+      "amount": 40333,
+      "message": None,
+      "gateway_response": "Successful",
+      "paid_at": "2024-08-22T09:15:02.000Z",
+      "created_at": "2024-08-22T09:14:24.000Z",
+      "channel": "card",
+      "currency": "NGN",
+      "ip_address": "197.210.54.33",
+      "metadata": None,
+      "log": {
+        "start_time": 1724318098,
+        "time_spent": 4,
+        "attempts": 1,
+        "errors": 0,
+        "success": True,
+        "mobile": False,
+        "input": [],
+        "history": [
+          {
+            "type": "action",
+            "message": "Attempted to pay with card",
+            "time": 3
+          },
+          {
+            "type": "success",
+            "message": "Successfully paid with card",
+            "time": 4
+          }
+        ]
+      },
+      "fees": 10283,
+      "fees_split": None,
+      "customer": {
+        "id": 181873746,
+        "first_name": None,
+        "last_name": None,
+        "email": "demo@test.com",
+        "phone": True,
+        "metadata": {
+          "custom_fields": [
+            {
+              "display_name": "Customer email",
+              "variable_name": "customer_email",
+              "value": "new@email.com"
+            }
+          ]
+        },
+        "customer_code": "CUS_1rkzaqsv4rrhqo6",
+        "risk_action": "default"
+      },
+      "authorization": {
+        "authorization_code": "AUTH_uh8bcl3zbn",
+        "bin": "408408",
+        "last4": "4081",
+        "exp_month": "12",
+        "exp_year": "2030",
+        "channel": "card",
+        "card_type": "visa ",
+        "bank": "TEST BANK",
+        "country_code": "NG",
+        "brand": "visa",
+        "reusable": True,
+        "signature": "SIG_yEXu7dLBeqG0kU7g95Ke",
+        "account_name": None
+      },
+      "plan": {},
+      "split": {},
+      "subaccount": {},
+      "order_id": None,
+      "paidAt": "2024-08-22T09:15:02.000Z",
+      "createdAt": "2024-08-22T09:14:24.000Z",
+      "requested_amount": 30050,
+      "source": {
+        "source": "merchant_api",
+        "type": "api",
+        "identifier": None,
+        "entry_point": "transaction_initialize"
+      },
+      "connect": None,
+      "pos_transaction_data": None
+    }
+  ],
+  "meta": {
+    "next": "dW5kZWZpbmVkOjQwMTM3MDk2MzU=",
+    "previous": None,
+    "perPage": 50
+  }    
+}
+
+mock_fetch_transactions = {
+  "status": True,
+  "message": "Transaction retrieved",
+  "data": {
+    "id": 4099260516,
+    "domain": "test",
+    "status": "success",
+    "reference": "re4lyvq3s3",
+    "receipt_number": None,
+    "amount": 40333,
+    "message": None,
+    "gateway_response": "Successful",
+    "helpdesk_link": None,
+    "paid_at": "2024-08-22T09:15:02.000Z",
+    "created_at": "2024-08-22T09:14:24.000Z",
+    "channel": "card",
+    "currency": "NGN",
+    "ip_address": "197.210.54.33",
+    "metadata": "",
+    "log": {
+      "start_time": 1724318098,
+      "time_spent": 4,
+      "attempts": 1,
+      "errors": 0,
+      "success": True,
+      "mobile": False,
+      "input": [],
+      "history": [
+        {
+          "type": "action",
+          "message": "Attempted to pay with card",
+          "time": 3
+        },
+        {
+          "type": "success",
+          "message": "Successfully paid with card",
+          "time": 4
+        }
+      ]
+    },
+    "fees": 10283,
+    "fees_split": None,
+    "authorization": {
+      "authorization_code": "AUTH_uh8bcl3zbn",
+      "bin": "408408",
+      "last4": "4081",
+      "exp_month": "12",
+      "exp_year": "2030",
+      "channel": "card",
+      "card_type": "visa ",
+      "bank": "TEST BANK",
+      "country_code": "NG",
+      "brand": "visa",
+      "reusable": True,
+      "signature": "SIG_yEXu7dLBeqG0kU7g95Ke",
+      "account_name": None
+    },
+    "customer": {
+      "id": 181873746,
+      "first_name": None,
+      "last_name": None,
+      "email": "demo@test.com",
+      "customer_code": "CUS_1rkzaqsv4rrhqo6",
+      "phone": None,
+      "metadata": {
+        "custom_fields": [
+          {
+            "display_name": "Customer email",
+            "variable_name": "customer_email",
+            "value": "new@email.com"
+          }
+        ]
+      },
+      "risk_action": "default",
+      "international_format_phone": None
+    },
+    "plan": {},
+    "subaccount": {},
+    "split": {},
+    "order_id": None,
+    "paidAt": "2024-08-22T09:15:02.000Z",
+    "createdAt": "2024-08-22T09:14:24.000Z",
+    "requested_amount": 30050,
+    "pos_transaction_data": None,
+    "source": {
+      "type": "api",
+      "source": "merchant_api",
+      "identifier": None
+    },
+    "fees_breakdown": None,
+    "connect": None
+  }    
+}
+
+mock_charge_authorization = {
+  "status": True,
+  "message": "Charge attempted",
+  "data": {
+    "amount": 35247,
+    "currency": "NGN",
+    "transaction_date": "2024-08-22T10:53:49.000Z",
+    "status": "success",
+    "reference": "0m7frfnr47ezyxl",
+    "domain": "test",
+    "metadata": "",
+    "gateway_response": "Approved",
+    "message": None,
+    "channel": "card",
+    "ip_address": None,
+    "log": None,
+    "fees": 10247,
+    "authorization": {
+      "authorization_code": "AUTH_uh8bcl3zbn",
+      "bin": "408408",
+      "last4": "4081",
+      "exp_month": "12",
+      "exp_year": "2030",
+      "channel": "card",
+      "card_type": "visa ",
+      "bank": "TEST BANK",
+      "country_code": "NG",
+      "brand": "visa",
+      "reusable": True,
+      "signature": "SIG_yEXu7dLBeqG0kU7g95Ke",
+      "account_name": None
+    },
+    "customer": {
+      "id": 181873746,
+      "first_name": None,
+      "last_name": None,
+      "email": "demo@test.com",
+      "customer_code": "CUS_1rkzaqsv4rrhqo6",
+      "phone": None,
+      "metadata": {
+        "custom_fields": [
+          {
+            "display_name": "Customer email",
+            "variable_name": "customer_email",
+            "value": "new@email.com"
+          }
+        ]
+      },
+      "risk_action": "default",
+      "international_format_phone": None
+    },
+    "plan": None,
+    "id": 4099490251
+  }    
+}
+
+mock_transaction_timeline = {
+  "status": True,
+  "message": "Timeline retrieved",
+  "data": {
+    "start_time": 1724318098,
+    "time_spent": 4,
+    "attempts": 1,
+    "errors": 0,
+    "success": True,
+    "mobile": False,
+    "input": [],
+    "history": [
+      {
+        "type": "action",
+        "message": "Attempted to pay with card",
+        "time": 3
+      },
+      {
+        "type": "success",
+        "message": "Successfully paid with card",
+        "time": 4
+      }
+    ]
+  }    
+}
+
+mock_transaction_totals = {
+  "status": True,
+  "message": "Transaction totals",
+  "data": {
+    "total_transactions": 42670,
+    "total_volume": 6617829946,
+    "total_volume_by_currency": [
+      {
+        "currency": "NGN",
+        "amount": 6617829946
+      },
+      {
+        "currency": "USD",
+        "amount": 28000
+      }
+    ],
+    "pending_transfers": 6617829946,
+    "pending_transfers_by_currency": [
+      {
+        "currency": "NGN",
+        "amount": 6617829946
+      },
+      {
+        "currency": "USD",
+        "amount": 28000
+      }
+    ]
+  }    
+}
+
+mock_export_transactions = {
+  "status": True,
+  "message": "Export successful",
+  "data": {
+    "path": "https://s3.eu-west-1.amazonaws.com/files.paystack.co/exports/463433/transactions/Integration_name_transactions_1724324423843.csv?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAI7CL5IZL2DJHOPPA%2F20240822%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20240822T110023Z&X-Amz-Expires=60&X-Amz-Signature=40525f4f361e07c09a445a1a6888d135758abd507ed988ee744c2d94ea14cf1e&X-Amz-SignedHeaders=host",
+    "expiresAt": "2024-08-22 11:01:23"
+  }    
+}
+
+mock_partial_debit = {
+  "status": True,
+  "message": "Charge attempted",
+  "data": {
+    "amount": 50000,
+    "currency": "NGN",
+    "transaction_date": "2024-08-22T11:13:48.000Z",
+    "status": "success",
+    "reference": "ofuhmnzw05vny9j",
+    "domain": "test",
+    "metadata": "",
+    "gateway_response": "Approved",
+    "message": None,
+    "channel": "card",
+    "ip_address": None,
+    "log": None,
+    "fees": 10350,
+    "authorization": {
+      "authorization_code": "AUTH_uh8bcl3zbn",
+      "bin": "408408",
+      "last4": "4081",
+      "exp_month": "12",
+      "exp_year": "2030",
+      "channel": "card",
+      "card_type": "visa ",
+      "bank": "TEST BANK",
+      "country_code": "NG",
+      "brand": "visa",
+      "reusable": True,
+      "signature": "SIG_yEXu7dLBeqG0kU7g95Ke",
+      "account_name": None
+    },
+    "customer": {
+      "id": 181873746,
+      "first_name": None,
+      "last_name": None,
+      "email": "demo@test.com",
+      "customer_code": "CUS_1rkzaqsv4rrhqo6",
+      "phone": None,
+      "metadata": {
+        "custom_fields": [
+          {
+            "display_name": "Customer email",
+            "variable_name": "customer_email",
+            "value": "new@email.com"
+          }
+        ]
+      },
+      "risk_action": "default",
+      "international_format_phone": None
+    },
+    "plan": 0,
+    "requested_amount": 50000,
+    "id": 4099546180
+  }    
+}

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -76,7 +76,6 @@ class TestCustomer(unittest.TestCase):
         self.assertEqual(response["data"]["last_name"], last_name)
         self.assertEqual(response["data"]["customer_code"], customer_code)
 
-
     ## the endpoint for these two does not exist
     # def test_whitelist_customer(self):
     #     customer_code = "CUS_ng9mw56ma4cx6x9"

--- a/tests/test_customer.py
+++ b/tests/test_customer.py
@@ -2,6 +2,7 @@ import sys
 import os 
 import unittest
 from dotenv import load_dotenv
+from unittest.mock import patch
 
 load_dotenv()
 
@@ -20,9 +21,13 @@ class TestCustomer(unittest.TestCase):
     def setUp(self) -> None:
         self.customer = Customer(TEST_KEY)
 
+    @patch("paystackpay.base.requests.post")
+    def test_create_customer(self, mock_post):
+        from .mock_responses.mock_customer import mock_create_customer_response
 
-    def test_create_customer(self):
-        # Test create_customer method
+        mock_post.return_value.json.return_value = mock_create_customer_response
+        mock_post.return_value.status = 200
+
         email = "test@example.com"
         first_name = "John"
         last_name = "Doe"
@@ -32,23 +37,44 @@ class TestCustomer(unittest.TestCase):
         self.assertEqual(response["status"],True)
         self.assertEqual(response["data"]["email"],email)
 
-    def test_list_customer(self):
+    @patch("paystackpay.base.requests.get")
+    def test_list_customer(self, mock_get):
+        from .mock_responses.mock_customer import mock_list_customer_response
+
+        mock_get.return_value.json.return_value = mock_list_customer_response
+        mock_get.return_value.status = 200
+
         response = self.customer.list_costumers()
         self.assertEqual(response["status"], True)
 
-    def test_fetch_customer(self):
+    @patch("paystackpay.base.requests.get")
+    def test_fetch_customer(self, mock_get):
+        from .mock_responses.mock_customer import mock_fetch_customer_response
+
+        mock_get.return_value.json.return_value = mock_fetch_customer_response
+        mock_get.return_value.status = 200
+
         email_or_customer_code = "test@example.com"
         response = self.customer.fetch_customer(email_or_customer_code)
         self.assertEqual(response["status"], True)
+        self.assertEqual(response["data"]["email"], email_or_customer_code)
 
+    @patch("paystackpay.base.requests.put")
+    def test_update_customer(self, mock_put):
+        from .mock_responses.mock_customer import mock_update_customer_response
 
-    def test_update_customer(self):
+        mock_put.return_value.status = 200
+        mock_put.return_value.json.return_value = mock_update_customer_response
+
         customer_code = "CUS_ng9mw56ma4cx6x9"
         first_name = "UpdatedFirstName"
         last_name = "UpdatedLastName"
 
         response = self.customer.update_customer(customer_code, first_name=first_name, last_name=last_name)
         self.assertEqual(response["status"], True)
+        self.assertEqual(response["data"]["first_name"], first_name)
+        self.assertEqual(response["data"]["last_name"], last_name)
+        self.assertEqual(response["data"]["customer_code"], customer_code)
 
 
     ## the endpoint for these two does not exist
@@ -62,8 +88,3 @@ class TestCustomer(unittest.TestCase):
     #     customer_code = "CUS_1234567890"
     #     response = self.customer.blacklist_customer(customer_code)
     #     self.assertEqual(response["status"], True)
-       
-
-
-
-    

--- a/tests/test_pay_request.py
+++ b/tests/test_pay_request.py
@@ -1,6 +1,7 @@
 import sys
 import os 
 import unittest
+from unittest.mock import patch
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -20,40 +21,64 @@ class TestPaymentRequest(unittest.TestCase):
         
         self.request = PaymentRequest(TEST_KEY)
 
-    # def test_create_payment_request(self):
-    #     customer_id = "CUS_ravy504uywyao9w"
-    #     description = "Payment For Hacks"
-    #     currency = "GHS"
-    #     amount = 1
+    @patch("paystackpay.base.requests.post")
+    def test_create_payment_request(self, mock_post):
+        from .mock_responses.mock_pay_request import mock_create_pay_request
 
-    #     response = self.request.create_payment_request(customer_id=customer_id,description=description,amount=amount,currency=currency)
-    #     print(response)
-    #     self.assertEqual(response['status'],True)
+        mock_post.return_value.json.return_value = mock_create_pay_request
+        mock_post.return_value.status = 200
 
+        customer_id = "CUS_ravy504uywyao9w"
+        description = "Payment For Hacks"
+        currency = "GHS"
+        amount = 1
 
-    # def test_fetch_payment_request(self):
-    #     request_code = "PRQ_53s49t73kq6qmsq"
-    #     response = self.request.fetch_payment_request(request_code=request_code)
-    #     self.assertEqual(response['status'],True)
-
-    # def test_list_payment_requests(self):
-    #     response = self.request.list_payment_requests()
-    #     print(response)
-
-
-    
-    # def test_verify_payment_request(self):
-    #     request_code = "PRQ_53s49t73kq6qmsq"
-    #     response = self.request.verify_payment_request(request_code=request_code)
-    #     print(response)
-    #     self.assertEqual(response['status'],True)
-
-    def test_send_notification(self):
-        request_code = "PRQ_53s49t73kq6qmsq"
-        response = self.request.send_notification(request_code=request_code)
-        print(response)
+        response = self.request.create_payment_request(customer_id=customer_id,description=description,amount=amount,currency=currency)
+        #incomplete
         self.assertEqual(response['status'],True)
 
+    @patch("paystackpay.base.requests.get")
+    def test_fetch_payment_request(self, mock_get):
+        from .mock_responses.mock_pay_request import mock_fetch_pay_request
 
+        mock_get.return_value.json.return_value = mock_fetch_pay_request
+        mock_get.return_value.status = 200
 
+        request_code = "PRQ_53s49t73kq6qmsq"
+        response = self.request.fetch_payment_request(request_code=request_code)
+        self.assertEqual(response['status'],True)
+        self.assertEqual(response['data']['request_code'], request_code)
 
+    @patch("paystackpay.base.requests.get")
+    def test_list_payment_requests(self, mock_get):
+        from .mock_responses.mock_pay_request import mock_list_pay_request
+
+        mock_get.return_value.json.return_value = mock_list_pay_request
+        mock_get.return_value.status = 200
+
+        response = self.request.list_payment_requests()
+        self.assertEqual(response['status'],True)
+
+    @patch("paystackpay.base.requests.get")
+    def test_verify_payment_request(self, mock_get):
+        from .mock_responses.mock_pay_request import mock_verify_pay_request
+
+        mock_get.return_value.json.return_value = mock_verify_pay_request
+        mock_get.return_value.status = 200
+
+        request_code = "PRQ_53s49t73kq6qmsq"
+        response = self.request.verify_payment_request(request_code=request_code)
+        self.assertEqual(response['status'],True)
+        self.assertEqual(response['data']['request_code'], request_code)
+
+    @patch("paystackpay.base.requests.post")
+    def test_send_notification(self, mock_post):
+        from .mock_responses.mock_pay_request import mock_send_notification
+
+        mock_post.return_value.json.return_value = mock_send_notification
+        mock_post.return_value.status = 200
+
+        request_code = "PRQ_53s49t73kq6qmsq"
+        response = self.request.send_notification(request_code=request_code)
+        self.assertEqual(response['status'], True)
+        self.assertEqual(response['message'], "Notification sent")

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,7 +1,8 @@
 import sys
-import os 
+import os
 import unittest
 from dotenv import load_dotenv
+from unittest.mock import patch
 
 load_dotenv()
 
@@ -17,11 +18,14 @@ from paystackpay.plans import Plan
 
 class TestPlan(unittest.TestCase):
     def setUp(self):
-
         self.plan = Plan(TEST_KEY)
 
+    @patch("paystackpay.base.requests.post")
+    def test_create_plan(self, mock_post):
+        from .mock_responses.mock_plans import mock_create_plans
 
-    def test_create_plan(self):
+        mock_post.return_value.json.return_value = mock_create_plans
+        mock_post.return_value.status = 200
 
         plan_name = "Monthly Platinum Session"
         interval = "monthly"
@@ -30,23 +34,46 @@ class TestPlan(unittest.TestCase):
 
         response = self.plan.create_plan(plan_name, interval, amount,currency)
         self.assertEqual(response["status"], True)
+        self.assertEqual(response["data"]["name"], plan_name)
+        self.assertEqual(response["data"]["amount"], amount)
 
-    def test_list_plans(self):
+    @patch("paystackpay.base.requests.get")
+    def test_list_plans(self, mock_get):
+        from .mock_responses.mock_plans import mock_list_plans
+
+        mock_get.return_value.json.return_value = mock_list_plans
+        mock_get.return_value.status = 200
+
         response = self.plan.list_plans()
         self.assertEqual(response["status"], True)
+        self.assertEqual(response["message"], "Plans retrieved")
 
-    def test_fetch_plan(self):
+    @patch("paystackpay.base.requests.get")
+    def test_fetch_plan(self, mock_get):
+        from .mock_responses.mock_plans import mock_fetch_plan
+
+        mock_get.return_value.json.return_value = mock_fetch_plan
+        mock_get.return_value.status = 200
+
         plan_id_or_code = "PLN_cfd3s2sdmqxravk"
         response = self.plan.fetch_plan(plan_id_or_code)
         self.assertEqual(response["status"], True)
+        if str(plan_id_or_code):
+            self.assertEqual(response["data"]["plan_code"], plan_id_or_code)
+        else:
+            self.assertEqual(response["data"]["id"], plan_id_or_code)
 
-    def test_update_plan(self):
+
+    @patch("paystackpay.base.requests.put")
+    def test_update_plan(self, mock_put):
+        from .mock_responses.mock_plans import mock_update_plan
+
+        mock_put.return_value.json.return_value = mock_update_plan
+        mock_put.return_value.status = 200
+        
         plan_id_or_code = "PLN_cfd3s2sdmqxravk"
         updated_plan_name = "Updated Plan"
         updated_interval = "weekly"
         updated_amount = 2000.0
         response = self.plan.update_plan(plan_name=updated_plan_name, interval=updated_interval, amount=updated_amount, id_or_code=plan_id_or_code)
         self.assertEqual(response["status"], True)
-
-
-

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -2,6 +2,7 @@ import sys
 import os 
 import unittest
 from dotenv import load_dotenv
+from unittest.mock import patch
 
 load_dotenv()
 
@@ -20,59 +21,114 @@ class TestTransaction(unittest.TestCase):
     def setUp(self) -> None:
         self.transaction = Transaction(TEST_KEY)
 
+    @patch("paystackpay.base.requests.post")
+    def test_initialize_transaction(self, mock_post):
+        from .mock_responses.mock_transactions import mock_initialize_transactions
 
+        mock_post.return_value.json.return_value = mock_initialize_transactions
+        mock_post.return_value.status = 200
 
-    def test_initialize_transaction(self):
         email = "cecilselorm34@gmail.com"
         amount = 1000
         currency = "GHS"
 
         response = self.transaction.initialize_transaction(email=email,amount=amount,currency=currency)
-        # print(response)
         self.assertEqual(response["status"],True)
+
+    @patch("paystackpay.base.requests.get")
+    def test_verify_transaction(self, mock_get):
+        from .mock_responses.mock_transactions import mock_verify_transaction
         
-    # def test_verify_transaction(self):
-    #     reference_id  = "mko157u44s"
-    #     response = self.transaction.verify_transaction(reference=reference_id)
-    #     print(response)
-    #     self.assertEqual(response["status"],True)
+        mock_get.return_value.json.return_value = mock_verify_transaction
+        mock_get.return_value.status = 200
 
+        reference_id  = "mko157u44s"
+        response = self.transaction.verify_transaction(reference=reference_id)
+        self.assertEqual(response["status"],True)
+        self.assertEqual(response["data"]["reference"], reference_id)
 
-    # def test_transaction_list(self):
-    #     response = self.transaction.transaction_list()
-    #     self.assertEqual(response["status"], True)
+    @patch("paystackpay.base.requests.get")
+    def test_transaction_list(self, mock_get):
+        from .mock_responses.mock_transactions import mock_list_transactions
 
-    # def test_fetch_transaction(self):
-    #     transaction_id = "some_transaction_id"
-    #     response = self.transaction.fetch_transaction(transaction_id=transaction_id)
-    #     self.assertEqual(response["status"], True)
+        mock_get.return_value.json.return_value = mock_list_transactions
+        mock_get.return_value.status = 200
 
-    # def test_charge_authorization(self):
-    #     email = "cecilselorm34@gmail.com"
-    #     amount = 500
-    #     auth_code = "some_authorization_code"
-    #     response = self.transaction.charge_authorization(email=email, amount=amount, auth_code=auth_code)
-    #     self.assertEqual(response["status"], True)
+        response = self.transaction.transaction_list()
+        self.assertEqual(response["status"], True)
+        self.assertEqual(response["data"][0]["status"], "success")
 
-    # def test_view_transaction_timeline(self):
-    #     tran_id_reference = "some_transaction_reference"
-    #     response = self.transaction.view_transaction_timeline(tran_id_reference=tran_id_reference)
-    #     self.assertEqual(response["status"], True)
+    @patch("paystackpay.base.requests.get")
+    def test_fetch_transaction(self, mock_get):
+        from .mock_responses.mock_transactions import mock_fetch_transactions
 
-    # def test_transaction_totals(self):
-    #     response = self.transaction.transaction_totals()
-    #     self.assertEqual(response["status"], True)
+        mock_get.return_value.json.return_value = mock_fetch_transactions
+        mock_get.return_value.status = 200
 
-    # def test_export_transaction(self):
-    #     response = self.transaction.export_transaction()
-    #     self.assertEqual(response["status"], True)
+        transaction_id = "4099260516"
+        response = self.transaction.fetch_transaction(transaction_id=transaction_id)
+        self.assertEqual(response["status"], True)
+        self.assertEqual(response["data"]["status"], "success")
+        self.assertEqual(response["data"]["id"], int(transaction_id))
 
-    # def test_partial_debit(self):
-    #     email = "cecilselorm34@gmail.com"
-    #     amount = 200
-    #     auth_code = "some_authorization_code"
-    #     response = self.transaction.partial_debit(auth_code=auth_code, email=email, amount=amount)
-    #     self.assertEqual(response["status"], True)
+    @patch("paystackpay.base.requests.post")
+    def test_charge_authorization(self, mock_post):
+        from .mock_responses.mock_transactions import mock_charge_authorization
 
+        mock_post.return_value.json.return_value = mock_charge_authorization
+        mock_post.return_value.status = 200
 
+        email = "cecilselorm34@gmail.com"
+        amount = 500
+        auth_code = "AUTH_uh8bcl3zbn"
+        response = self.transaction.charge_authorization(email=email, amount=amount, auth_code=auth_code)
+        self.assertEqual(response["status"], True)
+        self.assertEqual(response["data"]["authorization"]["authorization_code"], auth_code)
 
+    @patch("paystackpay.base.requests.get")
+    def test_view_transaction_timeline(self, mock_get):
+        from .mock_responses.mock_transactions import mock_transaction_timeline
+
+        mock_get.return_value.json.return_value = mock_transaction_timeline
+        mock_get.return_value.status = 200
+
+        tran_id_reference = "some_transaction_reference"
+        response = self.transaction.view_transaction_timeline(tran_id_reference=tran_id_reference)
+        self.assertEqual(response["status"], True)
+        self.assertEqual(response["data"]["success"], True)
+
+    @patch("paystackpay.base.requests.get")
+    def test_transaction_totals(self, mock_get):
+        from .mock_responses.mock_transactions import mock_transaction_totals
+
+        mock_get.return_value.json.return_value = mock_transaction_totals
+        mock_get.return_value.status = 200
+
+        response = self.transaction.transaction_totals()
+        self.assertEqual(response["status"], True)
+        self.assertEqual(response["message"], "Transaction totals")
+
+    @patch("paystackpay.base.requests.get")                              
+    def test_export_transaction(self, mock_get):
+        from .mock_responses.mock_transactions import mock_export_transactions
+
+        mock_get.return_value.json.return_value = mock_export_transactions
+        mock_get.return_value.status = 200
+
+        response = self.transaction.export_transaction()
+        self.assertEqual(response["status"], True)
+        self.assertEqual(response["message"], "Export successful")
+
+    @patch("paystackpay.base.requests.post")
+    def test_partial_debit(self, mock_post):
+        from .mock_responses.mock_transactions import mock_partial_debit
+
+        mock_post.return_value.json.return_value = mock_partial_debit
+        mock_post.return_value.status = 200
+
+        email = "cecilselorm34@gmail.com"
+        amount = 200
+        auth_code = "AUTH_uh8bcl3zbn"
+        response = self.transaction.partial_debit(auth_code=auth_code, email=email, amount=amount)
+        self.assertEqual(response["status"], True)
+        self.assertEqual(response["data"]["authorization"]["authorization_code"], auth_code)


### PR DESCRIPTION
**This pull request adds unittests to customer, pay_request, plans and transaction modules utilizing mock object responses to avoid calling the api each time you run a test. This pull request doesn't alter the functionality of modules.**

**changes i made:**
- Added unittests to the above mentioned modules
- Removed the previously existing test (they will be added in the integration testing)
**Benefits:**
- Cut down time to set up for first time contribution to the repo


**More functionality coverage will be added later with Integration tests**